### PR TITLE
Ot146 59 endpoint eliminacion slides

### DIFF
--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultSlidesGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultSlidesGateway.java
@@ -4,11 +4,11 @@ import com.alkemy.ong.data.entity.SlidesEntity;
 import com.alkemy.ong.data.repository.SlidesRepository;
 import com.alkemy.ong.domain.slides.SlidesGateway;
 import com.alkemy.ong.domain.slides.Slides;
+import com.alkemy.ong.web.exceptions.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static java.time.LocalDateTime.now;
 import static java.util.stream.Collectors.toList;
 
 @Component
@@ -44,7 +44,14 @@ public class DefaultSlidesGateway implements SlidesGateway {
 
     @Override
     public void delete(Long id) {
-        slidesRepository.deleteById(id);
+
+        SlidesEntity slideToDelete = slidesRepository
+                .findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Cannot find slide with id: " + id));
+
+        slideToDelete.setDeleted(true);
+
+        slidesRepository.save(slideToDelete);
     }
 
     @Override

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultSlidesGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultSlidesGateway.java
@@ -43,6 +43,11 @@ public class DefaultSlidesGateway implements SlidesGateway {
     }
 
     @Override
+    public void delete(Long id) {
+        slidesRepository.deleteById(id);
+    }
+
+    @Override
     public List<Slides> findAll() {
         List<SlidesEntity> slidesEntityList = slidesRepository.findAll();
 

--- a/src/main/java/com/alkemy/ong/domain/slides/SlidesGateway.java
+++ b/src/main/java/com/alkemy/ong/domain/slides/SlidesGateway.java
@@ -3,5 +3,6 @@ package com.alkemy.ong.domain.slides;
 import java.util.List;
 
 public interface SlidesGateway {
+    void delete(Long id);
     List<Slides> findAll();
 }

--- a/src/main/java/com/alkemy/ong/domain/slides/SlidesService.java
+++ b/src/main/java/com/alkemy/ong/domain/slides/SlidesService.java
@@ -11,5 +11,7 @@ public class SlidesService {
         this.slidesGateways = slidesGateways;
     }
 
+    public void delete(Long id){ slidesGateways.delete(id); }
+
     public List<Slides> findAll(){ return slidesGateways.findAll();  }
 }

--- a/src/main/java/com/alkemy/ong/web/controller/SlidesController.java
+++ b/src/main/java/com/alkemy/ong/web/controller/SlidesController.java
@@ -7,16 +7,13 @@ import lombok.*;
 import org.springframework.beans.BeanUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.alkemy.ong.web.controller.SlidesController.SlidesDto.toDto;
 import static java.util.stream.Collectors.toList;

--- a/src/main/java/com/alkemy/ong/web/controller/SlidesController.java
+++ b/src/main/java/com/alkemy/ong/web/controller/SlidesController.java
@@ -48,6 +48,12 @@ public class SlidesController {
         return new ResponseEntity<>(returnValue, HttpStatus.OK);
     }
 
+    @DeleteMapping(path = "/{id}")
+    public ResponseEntity<Void> deleteSlide(@PathVariable Long id){
+        slidesService.delete(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     @Getter
     @Setter
     @AllArgsConstructor

--- a/src/main/java/com/alkemy/ong/web/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/alkemy/ong/web/exceptions/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.web.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -10,7 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 @ControllerAdvice
 public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @org.springframework.web.bind.annotation.ExceptionHandler({
+    @ExceptionHandler({
             BadRequestException.class,
             org.springframework.web.HttpRequestMethodNotSupportedException.class,
             org.springframework.web.bind.MethodArgumentNotValidException.class,
@@ -22,5 +23,12 @@ public class GlobalExceptionHandler {
     @ResponseBody
     public ErrorResponse badRequest(HttpServletRequest request, Exception e){
         return new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage(), request.getRequestURI());
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ResourceNotFoundException.class)
+    @ResponseBody
+    public ErrorResponse notFound(HttpServletRequest request, Exception e){
+        return new ErrorResponse(HttpStatus.NOT_FOUND, e.getMessage(), request.getRequestURI());
     }
 }

--- a/src/main/java/com/alkemy/ong/web/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/alkemy/ong/web/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.alkemy.ong.web.exceptions;
+
+
+public class ResourceNotFoundException extends RuntimeException{
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Criterios de aceptación:

    Se debe hacer una petición DELETE /Slides/:id 

    Deberá validar que el slide existe y eliminarlo, caso contrario devolver un error

Como el método `deleteById` ya está implementado y, maneja excepciones si no se encuentra dicho id, no vi necesario implementar los handlers de error propios.